### PR TITLE
UPDATE: plotNeutrophilMovie.m different data input.

### DIFF
--- a/neutrophilAnalysis.m
+++ b/neutrophilAnalysis.m
@@ -10,6 +10,7 @@ function [handles]= neutrophilAnalysis(dataInName,numLevelsToReduce,...
 %[handles]= neutrophilAnalysis(dataInName,numLevelsToReduce,...
 %                               dataStructure,thresLevels,minBlob)
 %
+%
 %--------------------------------------------------------------------------
 % neutrophilAnalysis is the main routine for the  neutrophil analysis
 %     All other subroutines are called from here. It computes the handles

--- a/plotNeutrophilMovie.m
+++ b/plotNeutrophilMovie.m
@@ -11,19 +11,24 @@ function plotNeutrophilMovie (handlesDir,plotOption,tracksToPlot,framesToPlot)
 %         handlesDir:       path to where the handles are saved, it also 
 %                           requires the dataR to be stored somewhere close by
 %         
-%         plotOption:       it can plot in many ways:
-%                             1 Neutrophil intensity in green
-%                             2 Neutrophil intensity in green plus a slice of DIC
-%                             3 Neutrophil intensity in JET2
-%                             4 Neutrophil intensity in JET2 plus a slice of DIC
-%                             5 Neutrophil Labels in JET2
-%                             6 Neutrophil Labels in JET2 plus a slice of DIC
-%                             7 Neutrophil Intensity in green without tracks or DIC
-%                             8 Neutrophil Intensity in green plus DIC without tracks
-%                             9 Neutrophil intensity in green SHORT TRACKS
-%                             10 Neutrophil intensity in green plus
+%         plotOption:       it can plot in many ways, either by a number:
+%                             - 1 Neutrophil intensity in green
+%                             - 2 Neutrophil intensity in green plus a slice of DIC
+%                             - 3 Neutrophil intensity in JET2
+%                             - 4 Neutrophil intensity in JET2 plus a slice of DIC
+%                             - 5 Neutrophil Labels in JET2
+%                             - 6 Neutrophil Labels in JET2 plus a slice of DIC
+%                             - 7 Neutrophil Intensity in green without tracks or DIC
+%                             - 8 Neutrophil Intensity in green plus DIC without tracks
+%                             - 9 Neutrophil intensity in green SHORT TRACKS
+%                             - 10 Neutrophil intensity in green plus
 %                             a slice of DICSHORT TRACKS
-%                             path-to-data
+%                           or a string:
+%                             - path-to-data. '/full/path/to/data/folder'
+%                             with either '.mat' or '.tif' files.
+%                             - Use the string 'folder' to prompt the user 
+%                             to 
+%                             
 %
 %         tracksToPlot:     subset of tracks to plot
 %

--- a/plotTracks.m
+++ b/plotTracks.m
@@ -464,6 +464,7 @@ else
                                          'FitHeightToText','on');
 
             end
+            colormap jet;
 
           case 3
             %------- highlights longer (in number of frames) branches


### PR DESCRIPTION
Added functionality to use the function plotNeutrophilMovie, without depending on the `_mat_Re/` and `_mat_La/` directories. User is now able to search for a folder which contains different data from the one processed by phagosight. Useful when analysing a specific channel of a dataset, but want to visualise the full dataset with all its channels. 

Usage:
```Matlab
handlesDir = '/path/to/Data_mat_Ha/';
newDataDir = '/path/to/Data/to/be/Displayed';

plotNeutrophilMovie(handlesDir, newDataDir);
```
where `handlesDir`, as before, is the folder that contains the handles structure. The variable `newDataDir` can be one of two options:

1. The path to folder with data (.mat and .tif files supported)
2. 'The string folder', which allow the user to select the folder to work with, i.e
```Matlab
handlesDir = '/path/to/Data_mat_Ha/';

plotNeutrophilMovie(handlesDir, 'folder');
```

Commit changes include the changes to `plotNeutrophilMovie`, and the documentation at the beginning of the function. A screenshot (for size purposes) of the file is included showing the visualisation. 
![screenshot_video1](https://cloud.githubusercontent.com/assets/9891700/24501136/2970bfc2-1540-11e7-88ac-a34b5cc65b09.png)




